### PR TITLE
Iterations: scripts to switch between the default menu, obmenu-generator, and back again

### DIFF
--- a/genmenu
+++ b/genmenu
@@ -20,5 +20,5 @@ if [ -f "$menuold" ]
         obmenu-generator -s -c
         notify-send 'Success!' 'A new menu was generated.'
     else
-        notify-send 'Ooops!' 'It seems a backup was never made or is missing, nothing changed.'
+        notify-send 'Ooops!' 'A backup was never made & is required.. Nothing changed.'
 fi

--- a/genmenu
+++ b/genmenu
@@ -1,17 +1,16 @@
 #!/bin/bash
 
+# drop ot on error
+set -e
+
 ## Declaring some variables
 config="$HOME/.config/openbox"
-menunow="$config/.config/openbox/menu.xml"
 menuold="$config/menu-static.xml"
 
 
 ## Will backup current static menu.xml to menu-static.xml
 
-if [ -f "$menunow" ]
-    then
-        cp $HOME/.config/openbox/menu.xml $HOME/.config/openbox/menu-static.xml
-fi
+cp $HOME/.config/openbox/menu.xml $HOME/.config/openbox/menu-static.xml
 
 
 ## Setup New Menu

--- a/genmenu
+++ b/genmenu
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+## Declaring some variables
+config="$HOME/.config/openbox"
+menunow="$config/.config/openbox/menu.xml"
+menuold="$config/menu-static.xml"
+
+
+## Will backup current static menu.xml to menu-static.xml
+
+if [ -f "$menunow" ]
+    then
+        cp $HOME/.config/openbox/menu.xml $HOME/.config/openbox/menu-static.xml
+fi
+
+
+## Setup New Menu
+
+if [ -f "$menuold" ]
+    then
+        obmenu-generator -s -c
+        notify-send 'Success!' 'A new menu was generated.'
+    else
+        notify-send 'Ooops!' 'It seems a backup was never made or is missing, nothing changed.'
+fi

--- a/oldmenu
+++ b/oldmenu
@@ -4,7 +4,8 @@
 set -e
 
 ## Declaring some variables
-menuold="$HOME/.config/openbox/menu-static.xml"
+config="$HOME/.config/openbox"
+menuold="$config/menu-static.xml"
 
 
 ## Revert to Backup menu

--- a/oldmenu
+++ b/oldmenu
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# drop out on error
+set -e
+
+## Declaring some variables
+menuold="$HOME/.config/openbox/menu-static.xml"
+
+
+## Revert to Backup menu
+
+if [ -f "$menuold" ]
+    then
+        cp $HOME/.config/openbox/menu-static.xml $HOME/.config/openbox/menu.xml
+        openbox --reconfigure
+        notify-send 'Success!' 'Reverted to menu before switching.'
+    else
+        notify-send 'Ooops!' 'It seems a backup was never made or is missing.'
+fi


### PR DESCRIPTION
genmenu: 
Makes a backup of the current menu.xml in the openbox config folder.
Then it will invoke obmenu-generator to make a static menu.
It gives a little notification through notifyd telling you if it was successful or if there was an issue.

oldmenu: 
Takes the backup that genmenu makes and replaces the obmenu generated menu with it
Then it reconfigures openbox
Again it gives a little notification through notifyd letting you know the outcome